### PR TITLE
Fix unset author aborting local Dev Container build

### DIFF
--- a/.devcontainer/on_create.sh
+++ b/.devcontainer/on_create.sh
@@ -27,7 +27,7 @@ git add $BASE_PATH/gem5-config.json
 git add $BASE_PATH/workloads/resources.json
 
 if ! git config user.email >/dev/null; then
-  echo "Author unset. Please run the following command manually:"
+  echo "Author unset. Please run the following commands manually:"
   echo
   echo "    git config --global user.email \"you@example.com\""
   echo "    git config --global user.name \"Your Name\""

--- a/.devcontainer/on_create.sh
+++ b/.devcontainer/on_create.sh
@@ -25,13 +25,14 @@ sed -i "s|/workspaces/gem5-assignment-template|$BASE_PATH|g" $BASE_PATH/workload
 
 git add $BASE_PATH/gem5-config.json
 git add $BASE_PATH/workloads/resources.json
-git commit -m "Update resource paths for this repository" || true
 
-if ! git diff-index --quiet HEAD --; then
-  echo "Failed to commit changes. Please run the following command manually:"
+if ! git config user.email >/dev/null; then
+  echo "Author unset. Please run the following command manually:"
   echo
-  echo "    git config --global user.name <Your Name>"
-  echo "    git config --global user.email <Your Email>"
+  echo "    git config --global user.email \"you@example.com\""
+  echo "    git config --global user.name \"Your Name\""
   echo "    git commit -m \"Update resource paths for this repository\""
   echo
+else
+  git commit -m "Update resource paths for this repository"
 fi

--- a/.devcontainer/on_create.sh
+++ b/.devcontainer/on_create.sh
@@ -25,4 +25,13 @@ sed -i "s|/workspaces/gem5-assignment-template|$BASE_PATH|g" $BASE_PATH/workload
 
 git add $BASE_PATH/gem5-config.json
 git add $BASE_PATH/workloads/resources.json
-git commit -m "Update resource paths for this repository"
+git commit -m "Update resource paths for this repository" || true
+
+if ! git diff-index --quiet HEAD --; then
+  echo "Failed to commit changes. Please run the following command manually:"
+  echo
+  echo "    git config --global user.name <Your Name>"
+  echo "    git config --global user.email <Your Email>"
+  echo "    git commit -m \"Update resource paths for this repository\""
+  echo
+fi


### PR DESCRIPTION
The `git commit` command in `.devcontainer/on_create.sh` fails when building the Dev Container locally due to unset git author, causing the Dev Container to be immediately discarded by VSCode. Instead of letting it fail, the script now detects if author is unset, and alert the user to manually commit after setting an author.